### PR TITLE
feat: enhance answer choice quality checks and guidelines for GH-300 items

### DIFF
--- a/.github/agents/gh300-cert-buddy-agent.agent.md
+++ b/.github/agents/gh300-cert-buddy-agent.agent.md
@@ -59,6 +59,8 @@ Follow all rules in `references/style-guide.md` for Microsoft Writing Style Guid
 - Exactly 2 sentences per rationale entry (why correct/incorrect + context).
 - No "all of the above" or "none of the above."
 - Distractors must reference real Copilot features, settings, policies, or workflows (never invented ones).
+- Answer choices must be grammatically parallel and comparable in specificity.
+- Keep option lengths balanced so no single option is an obvious tell.
 
 ## Answer choice randomization (non-negotiable)
 

--- a/.github/skills/gh300-item-creator/SKILL.md
+++ b/.github/skills/gh300-item-creator/SKILL.md
@@ -55,6 +55,8 @@ Use the skill-local bundle so this skill is reproducible and teachable as a pack
 - Exactly 1 correct answer unless the requested item type explicitly differs.
 - No "all of the above" or "none of the above."
 - Distractors must be plausible and real.
+- Answer choices must be grammatically parallel, equally plausible, and similar in detail level.
+- Keep option lengths balanced so the correct answer is not identifiable by being longest or most detailed.
 
 ## Answer choice randomization (non-negotiable)
 
@@ -72,10 +74,11 @@ Use fictional company names from `references/fictional-companies.md` for scenari
 4. Pick a random fictional company from `references/fictional-companies.md` and draft a workplace scenario stem.
 5. Randomly assign the correct answer to A, B, C, or D. Write 1 correct answer and 3 plausible distractors.
 6. Run a mutual exclusivity check on answer choices.
-7. Run a terminology check.
-8. Run a clarity check.
-9. Run the checks in `resources/item-quality-checklist.md` and use `scripts/validate-output.js` logic as a final structure gate.
-10. Prepare rationale internally but **do not deliver it yet**.
+7. Run an answer-parallelism check (grammar pattern, detail level, and length balance) to remove giveaway signals.
+8. Run a terminology check.
+9. Run a clarity check.
+10. Run the checks in `resources/item-quality-checklist.md` and use `scripts/validate-output.js` logic as a final structure gate.
+11. Prepare rationale internally but **do not deliver it yet**.
 
 ## Recipe: responsible AI principle items
 

--- a/.github/skills/gh300-item-creator/resources/item-quality-checklist.md
+++ b/.github/skills/gh300-item-creator/resources/item-quality-checklist.md
@@ -8,6 +8,8 @@ Use this checklist before delivering a question.
 - One correct answer only.
 - Correct letter randomized across a set.
 - Distractors are plausible and mutually exclusive.
+- All answer choices are grammatically parallel and equally plausible.
+- Option lengths are balanced (no obvious longest or shortest giveaway choice).
 - No answer is a subset of another answer.
 - No all/none/both constructions.
 - Scenario uses a randomized fictional company.

--- a/.github/skills/gh300-item-creator/resources/source-pack.md
+++ b/.github/skills/gh300-item-creator/resources/source-pack.md
@@ -24,3 +24,4 @@ Use these sources in this order of precedence when writing GH-300 practice items
 - Do not use contractions.
 - Do not use all/none of the above patterns.
 - Keep distractors plausible and tied to real product behavior.
+- Keep answer choices parallel in grammar and length so no option is an obvious tell.

--- a/.github/skills/gh300-item-creator/scripts/validate-output.js
+++ b/.github/skills/gh300-item-creator/scripts/validate-output.js
@@ -4,6 +4,34 @@ const fs = require("fs");
 
 const input = fs.readFileSync(0, "utf8");
 const issues = [];
+const choicePattern = /^\s*(?:-\s*)?([ABCD])\s*:\s*["'`]?(.+?)["'`]?\s*$/i;
+
+function normalizeChoice(choiceText) {
+  return choiceText.trim().replace(/\s+/g, " ");
+}
+
+function extractChoices(text) {
+  const found = {};
+  for (const line of text.split(/\r?\n/)) {
+    const match = line.match(choicePattern);
+    if (!match) {
+      continue;
+    }
+
+    const label = match[1].toUpperCase();
+    if (!found[label]) {
+      found[label] = normalizeChoice(match[2]);
+    }
+
+    if (["A", "B", "C", "D"].every((letter) => found[letter])) {
+      break;
+    }
+  }
+  return found;
+}
+
+const choices = extractChoices(input);
+const hasAllChoices = ["A", "B", "C", "D"].every((letter) => choices[letter]);
 
 if (
   !/\bA\s*:/m.test(input) ||
@@ -30,8 +58,46 @@ if (!/metadata/i.test(input) || !/question/i.test(input)) {
   issues.push("Missing expected GH-300 item structure sections.");
 }
 
+if (hasAllChoices) {
+  const lengths = Object.entries(choices).map(([label, text]) => ({
+    label,
+    length: text.length,
+  }));
+  const values = lengths.map((entry) => entry.length);
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const spread = max - min;
+  const ratio = min > 0 ? max / min : Infinity;
+
+  if (spread > 40 && ratio > 1.4) {
+    issues.push(
+      "Answer choice lengths are too uneven. Keep options parallel and similar in length.",
+    );
+  }
+
+  const correctMatch = input.match(
+    /correct answer(?:\s+letter)?\s*(?:is|:)\s*([ABCD])/i,
+  );
+  if (correctMatch) {
+    const correctLetter = correctMatch[1].toUpperCase();
+    const sorted = [...lengths].sort((a, b) => b.length - a.length);
+    const correctEntry = lengths.find((entry) => entry.label === correctLetter);
+
+    if (
+      correctEntry &&
+      sorted.length >= 2 &&
+      correctEntry.length === sorted[0].length &&
+      sorted[0].length - sorted[1].length >= 12
+    ) {
+      issues.push(
+        "Correct answer is conspicuously longer than other options. Reduce giveaway length bias.",
+      );
+    }
+  }
+}
+
 if (issues.length === 0) {
-  console.log("PASS: Item draft meets baseline structural checks.");
+  console.log("PASS: Item draft meets structural and answer-quality checks.");
   process.exit(0);
 }
 


### PR DESCRIPTION
## Summary
- tighten GH-300 item-writing rules to require parallel, plausible, length-balanced choices
- add checklist and source-pack constraints to reduce obvious correct-answer tells
- enhance item validator to flag uneven choice lengths and conspicuously longest correct options

## Files changed
- .github/agents/gh300-cert-buddy-agent.agent.md
- .github/skills/gh300-item-creator/SKILL.md
- .github/skills/gh300-item-creator/resources/item-quality-checklist.md
- .github/skills/gh300-item-creator/resources/source-pack.md
- .github/skills/gh300-item-creator/scripts/validate-output.js
